### PR TITLE
Add Google and GitHub OAuth2 flow

### DIFF
--- a/pytest/test_oauth.py
+++ b/pytest/test_oauth.py
@@ -1,0 +1,113 @@
+import os
+import subprocess
+import pathlib
+import time
+import socket
+import urllib.request
+import urllib.error
+import shutil
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+PORT = 9224
+
+
+def wait_for_port(host: str, port: int, timeout: float = 5.0) -> None:
+    """Poll until the TCP port opens or timeout expires."""
+    start = time.time()
+    while time.time() - start < timeout:
+        with socket.socket() as sock:
+            try:
+                sock.connect((host, port))
+            except OSError:
+                time.sleep(0.1)
+                continue
+            return
+    raise RuntimeError(f"port {port} on {host} did not open")
+
+
+@pytest.fixture()
+def server():
+    if shutil.which("zig") is None:
+        pytest.skip("zig not installed")
+    env = os.environ.copy()
+    env.update(
+        {
+            "GOOGLE_CLIENT_ID": "id",
+            "GOOGLE_CLIENT_SECRET": "secret",
+            "GOOGLE_REDIRECT_URI": "http://localhost/auth/google/callback",
+            "GITHUB_CLIENT_ID": "id",
+            "GITHUB_CLIENT_SECRET": "secret",
+            "GITHUB_REDIRECT_URI": "http://localhost/auth/github/callback",
+        }
+    )
+    proc = subprocess.Popen(["zig", "build", "run"], cwd=ROOT, env=env)
+    try:
+        wait_for_port("127.0.0.1", PORT, timeout=10)
+        yield
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise urllib.error.HTTPError(req.full_url, code, msg, headers, fp)
+
+
+def opener_no_redirect():
+    return urllib.request.build_opener(NoRedirect)
+
+
+def test_google_start_redirect(server):
+    opener = opener_no_redirect()
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        opener.open(f"http://127.0.0.1:{PORT}/auth/google")
+    assert exc.value.code == 302
+    assert "accounts.google.com" in exc.value.headers["Location"]
+
+
+def test_google_callback_requires_code(server):
+    opener = opener_no_redirect()
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        opener.open(f"http://127.0.0.1:{PORT}/auth/google/callback")
+    assert exc.value.code == 400
+
+
+def test_google_callback_bad_code(server):
+    opener = opener_no_redirect()
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        opener.open(
+            f"http://127.0.0.1:{PORT}/auth/google/callback?code=bad"
+        )
+    # Expect server to reject invalid code with 500
+    assert exc.value.code == 500
+
+
+def test_github_start_redirect(server):
+    opener = opener_no_redirect()
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        opener.open(f"http://127.0.0.1:{PORT}/auth/github")
+    assert exc.value.code == 302
+    assert "github.com/login/oauth" in exc.value.headers["Location"]
+
+
+def test_github_callback_requires_code(server):
+    opener = opener_no_redirect()
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        opener.open(f"http://127.0.0.1:{PORT}/auth/github/callback")
+    assert exc.value.code == 400
+
+
+def test_github_callback_bad_code(server):
+    opener = opener_no_redirect()
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        opener.open(
+            f"http://127.0.0.1:{PORT}/auth/github/callback?code=bad"
+        )
+    assert exc.value.code == 500
+

--- a/src/net/module.zig
+++ b/src/net/module.zig
@@ -1,6 +1,7 @@
 pub const host_ws = @import("websocket.zig").host;
 pub const host_http = @import("web.zig").host;
 const ws = @import("websocket");
+pub const oauth = @import("oauth.zig");
 
 pub const Conn = ws.Conn;
 

--- a/src/net/oauth.zig
+++ b/src/net/oauth.zig
@@ -1,0 +1,82 @@
+const std = @import("std");
+
+pub const Provider = enum { google, github };
+
+pub const Config = struct {
+    client_id: []const u8,
+    client_secret: []const u8,
+    redirect_uri: []const u8,
+};
+
+pub fn authUrl(alloc: std.mem.Allocator, provider: Provider, cfg: Config) ![]u8 {
+    return switch (provider) {
+        .google => try std.fmt.allocPrint(alloc,
+            "https://accounts.google.com/o/oauth2/v2/auth?client_id={s}&redirect_uri={s}&response_type=code&scope=openid%20email",
+            .{ cfg.client_id, cfg.redirect_uri }),
+        .github => try std.fmt.allocPrint(alloc,
+            "https://github.com/login/oauth/authorize?client_id={s}&redirect_uri={s}&scope=user:email",
+            .{ cfg.client_id, cfg.redirect_uri }),
+    };
+}
+
+pub fn exchangeCode(alloc: std.mem.Allocator, provider: Provider, cfg: Config, code: []const u8) ![]u8 {
+    var client = std.http.Client{ .allocator = alloc };
+    defer client.deinit();
+
+    const token_uri = switch (provider) {
+        .google => "https://oauth2.googleapis.com/token",
+        .github => "https://github.com/login/oauth/access_token",
+    };
+
+    var uri = try std.Uri.parse(token_uri);
+    var headers = std.http.Headers.init(alloc);
+    defer headers.deinit();
+    try headers.append("content-type", "application/x-www-form-urlencoded");
+
+    var body = switch (provider) {
+        .google => try std.fmt.allocPrint(alloc,
+            "code={s}&client_id={s}&client_secret={s}&redirect_uri={s}&grant_type=authorization_code",
+            .{ code, cfg.client_id, cfg.client_secret, cfg.redirect_uri }),
+        .github => try std.fmt.allocPrint(alloc,
+            "code={s}&client_id={s}&client_secret={s}&redirect_uri={s}",
+            .{ code, cfg.client_id, cfg.client_secret, cfg.redirect_uri }),
+    };
+    defer alloc.free(body);
+
+    var req = try client.request(.POST, uri, headers, body);
+    defer req.deinit();
+    try req.send();
+    const res = try req.finish();
+    const data = try res.reader().readAllAlloc(alloc, 16 * 1024);
+    return data;
+}
+
+test "authUrl builds google URL" {
+    var alloc = std.testing.allocator;
+    const cfg = Config{
+        .client_id = "id",
+        .client_secret = "secret",
+        .redirect_uri = "http://localhost",
+    };
+    const url = try authUrl(alloc, .google, cfg);
+    defer alloc.free(url);
+    try std.testing.expectEqualStrings(
+        "https://accounts.google.com/o/oauth2/v2/auth?client_id=id&redirect_uri=http://localhost&response_type=code&scope=openid%20email",
+        url,
+    );
+}
+
+test "authUrl builds github URL" {
+    var alloc = std.testing.allocator;
+    const cfg = Config{
+        .client_id = "id",
+        .client_secret = "secret",
+        .redirect_uri = "http://localhost",
+    };
+    const url = try authUrl(alloc, .github, cfg);
+    defer alloc.free(url);
+    try std.testing.expectEqualStrings(
+        "https://github.com/login/oauth/authorize?client_id=id&redirect_uri=http://localhost&scope=user:email",
+        url,
+    );
+}


### PR DESCRIPTION
## Summary
- add OAuth2 helpers for Google and GitHub
- wire OAuth2 start and callback routes into zzz web server
- add unit and integration tests for OAuth URLs
- exercise OAuth endpoints via pytest to verify redirects and error handling

## Testing
- `zig fmt src/net/oauth.zig src/net/web.zig` *(fails: command not found)*
- `zig build test` *(fails: command not found)*
- `pytest` *(2 failed: proxy rejected connection, 6 skipped: zig not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68950c9433ac832b978453d5826daed0