### PR TITLE
Enhance mock OAuth2 provider with scopes

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,8 +25,9 @@ services:
     command: python -m pytest
     volumes: [./pytest:/repo/pytest]
 
-  oauthmock:
+  oauth:
     image: tiangolo/uvicorn-gunicorn-fastapi:python3.11-slim
+    environment: ["CLIENT_ID=ninjamagic", "CLIENT_SECRET=secret"]
     volumes: [./oauth_mock.py:/app/main.py]
-    command: ["/bin/sh", "-c", "pip install --quiet faker && uvicorn main:app --host 0.0.0.0 --port 80"]
-    ports: ["8000:80"]
+    command: ["/bin/sh", "-c", "pip install --quiet faker && uvicorn main:app"]
+    ports: ["8000:8000"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,3 +24,9 @@ services:
     profiles: ["test"]
     command: python -m pytest
     volumes: [./pytest:/repo/pytest]
+
+  oauthmock:
+    image: tiangolo/uvicorn-gunicorn-fastapi:python3.11-slim
+    volumes: [./oauth_mock.py:/app/main.py]
+    command: ["/bin/sh", "-c", "pip install --quiet faker && uvicorn main:app --host 0.0.0.0 --port 80"]
+    ports: ["8000:80"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,6 +28,15 @@ services:
   oauth:
     image: tiangolo/uvicorn-gunicorn-fastapi:python3.11-slim
     environment: ["CLIENT_ID=ninjamagic", "CLIENT_SECRET=secret"]
-    volumes: [./oauth_mock.py:/app/main.py]
-    command: ["/bin/sh", "-c", "pip install --quiet faker && uvicorn main:app"]
+    volumes: [./pytest/oauth_provider.py:/app/main.py]
+    command: ["/bin/sh", "-c", "pip install --quiet faker && uvicorn main:app --host 0.0.0.0"]
     ports: ["8000:8000"]
+
+  oauthtest:
+    image: tiangolo/uvicorn-gunicorn-fastapi:python3.11-slim
+    environment:
+      - CLIENT_ID=ninjamagic
+      - CLIENT_SECRET=secret
+    volumes: [./pytest/oauth_test.py:/app/main.py]
+    command: ["/bin/sh", "-c", "pip install --quiet requests && uvicorn main:app --host 0.0.0.0"]
+    ports: ["8001:8000"]

--- a/oauth_mock.py
+++ b/oauth_mock.py
@@ -1,130 +1,324 @@
-from datetime import datetime, timedelta
-from typing import Dict, Set, Optional
+from datetime import datetime, timedelta, timezone
+from typing import Annotated, Set
 from uuid import uuid4
+from enum import StrEnum
 
-from fastapi import Depends, FastAPI, Form, Header, HTTPException, Query
+from fastapi import Depends, FastAPI, Form, HTTPException, Query, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from fastapi.responses import RedirectResponse
-from pydantic import BaseModel
-from faker import Faker
+from pydantic import BaseModel, HttpUrl
+from pydantic_settings import BaseSettings
 
+
+class Settings(BaseSettings):
+    """
+    Settings for the application. Set these via environment variables or a .env file.
+    """
+    client_id: str = "my-client-id"
+    client_secret: str = "my-client-secret"
+    permitted_redirect_uri: HttpUrl | None = None
+    app_url: str = "http://localhost:8000"
+
+
+class TokenRequest(BaseModel):
+    grant_type: str
+    code: str | None = None
+    redirect_uri: str | None = None
+    client_id: str | None = None
+    client_secret: str | None = None
+    refresh_token: str | None = None
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+    expires_in: int
+    refresh_token: str
+    scope: str
+
+
+class Scope(StrEnum):
+    openid = "openid"
+    profile = "profile"
+    email = "email"
+
+
+class UserInfo(BaseModel):
+    sub: str
+    name: str = ""
+    picture: str = ""
+    email: str = ""
+
+    def from_scopes(self, scopes: set[Scope]):
+        visible = {"sub": self.sub}
+
+        if Scope.profile in scopes:
+            visible["name"] = self.name
+            visible["picture"] = self.picture
+        
+        if Scope.email in scopes:
+            visible["email"] = self.email
+            
+        return UserInfo(**visible)
+
+
+class TokenInfo(BaseModel):
+    user: UserInfo
+    scopes: set[Scope]
+    expires_at: datetime
+    iss: str
+    aud: str
+
+
+class AuthCode(BaseModel):
+    """
+    A Pydantic model for an OAuth 2.0 authorization code.
+    This is a temporary, single-use credential.
+    """
+    scopes: set[str]
+    user: UserInfo
+    redirect_uri: str
+    client_id: str
+    expires_at: datetime
+    state: str
+
+
+class RefreshTokenInfo(BaseModel):
+    user: UserInfo
+    scopes: set[Scope]
+    expires_at: datetime
+    client_id: str
+
+
+settings = Settings()
 app = FastAPI()
-fake = Faker()
 
-auth_codes: Dict[str, Dict] = {}
-tokens: Dict[str, Dict] = {}
+auth_codes: dict[str, AuthCode] = {}
+tokens: dict[str, TokenInfo] = {
+    "valid_token_1": TokenInfo(
+        user=UserInfo(
+            sub="bobby123",
+            name="Bob Builder",
+            picture="http://example.com/bob.jpg",
+            email="bob.builder@example.com",
+        ),
+        scopes={Scope.profile, Scope.email, Scope.openid},
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        iss=settings.app_url,
+        aud=settings.client_id
+    ),
+    "valid_token_2": TokenInfo(
+        user=UserInfo(
+            sub="xoalicexo",
+            name="Alice Adventure",
+            picture="http://example.com/alice.jpg",
+            email="alice@wonderland.com",
+        ),
+        scopes={Scope.profile, Scope.openid},
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        iss=settings.app_url,
+        aud=settings.client_id
+    ),
+    "valid_token_3": TokenInfo(
+        user=UserInfo(
+            sub="magneto-incognito",
+        ),
+        scopes={Scope.openid},
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        iss=settings.app_url,
+        aud=settings.client_id
+    )
+}
 
-VALID_SCOPES = {"openid", "profile", "email"}
+refresh_tokens: dict[str, RefreshTokenInfo] = {}
+security = HTTPBearer()
+
+def get_session_data(
+    authorization: Annotated[HTTPAuthorizationCredentials, Depends(security)],
+) -> TokenInfo:
+    token_str = authorization.credentials
+    if authorization.scheme.lower() != "bearer" or token_str not in tokens:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid_token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    
+    token_info = tokens[token_str]
+
+    # Check for token expiration
+    if token_info.expires_at < datetime.now(datetime.timezone.utc):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="expired_token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    # Validate audience and issuer
+    if token_info.aud != settings.client_id or token_info.iss != settings.app_url:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid_token_claims",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    return token_info
+
+
+@app.get("/")
+def root() -> str:
+    return "Hello world!\n"
 
 
 @app.get("/authorize")
 def authorize(
-    response_type: str = Query(...),
-    client_id: str = Query(...),
-    redirect_uri: str = Query(...),
-    scope: str = Query(""),
-    state: str = Query(""),
-):
+    response_type: Annotated[str, Query()],
+    client_id: Annotated[str, Query()],
+    redirect_uri: Annotated[str, Query()],
+    scope: Annotated[str, Query()],
+    state: Annotated[str, Query()]
+) -> RedirectResponse:
     if response_type != "code":
-        raise HTTPException(status_code=400, detail="unsupported_response_type")
-    scopes = set(scope.split()) if scope else set()
-    invalid_scopes = scopes - VALID_SCOPES
-    if invalid_scopes:
         raise HTTPException(
-            status_code=400, detail=f"invalid_scope: {' '.join(invalid_scopes)}"
+            status_code=400,
+            detail="unsupported_response_type"
         )
-    user = {
-        "sub": fake.uuid4(),
-        "name": fake.name(),
-        "email": fake.email(),
-        "picture": fake.image_url(),
-    }
+    
+    scopes = set(scope.split()) if scope else set()
+    valid_scopes = set(Scope.__members__.values())
+    if invalid_scopes := scopes - valid_scopes:
+        raise HTTPException(
+            status_code=400,
+            detail=f"invalid_scope: {' '.join(invalid_scopes)}"
+        )
+    
     code = uuid4().hex
-    auth_codes[code] = {"scopes": scopes, "user": user}
+    auth_codes[code] = AuthCode(
+        scopes=scopes,
+        user=UserInfo(
+            sub="charlesincharge",
+            name="Charlie von Charge",
+            email="chazzychef@example.com",
+            picture="https://placehold.co/chaz-kills-it.png",
+        ),
+        redirect_uri=redirect_uri,
+        client_id=client_id,
+        expires_at=datetime.now(datetime.timezone.utc) + timedelta(minutes=5),
+        state=state
+    )
     redirect = f"{redirect_uri}?code={code}"
     if state:
         redirect += f"&state={state}"
     return RedirectResponse(redirect)
 
 
-class AuthorizationCodeRequestForm:
-    def __init__(
-        self,
-        grant_type: str = Form(...),
-        code: str = Form(...),
-        redirect_uri: str = Form(...),
-        client_id: str = Form(...),
-        client_secret: str = Form(...),
-    ):
-        self.grant_type = grant_type
-        self.code = code
-        self.redirect_uri = redirect_uri
-        self.client_id = client_id
-        self.client_secret = client_secret
+@app.post("/token")
+async def token(
+    grant_type: Annotated[str, Form()],
+    code: Annotated[str, Form()],
+    redirect_uri: Annotated[str, Form()],
+    client_id: Annotated[str, Form()],
+    client_secret: Annotated[str, Form()],
+    refresh_token: Annotated[str | None, Form()] = None,
+    state: Annotated[str | None, Form()] = None
+) -> TokenResponse:
+    if grant_type == "authorization_code":
+            
+        if code not in auth_codes:
+            raise HTTPException(status_code=400, detail="invalid_grant")
+
+        data = auth_codes.pop(code)
+        
+        if client_id != data.client_id:
+            raise HTTPException(status_code=400, detail="invalid_client")
+        if client_secret != settings.client_secret:
+            raise HTTPException(status_code=401, detail="invalid_client_secret")
+        if data.redirect_uri != redirect_uri:
+            raise HTTPException(status_code=400, detail="invalid_redirect")
+        if state and data.state != state:
+            raise HTTPException(status_code=400, detail="invalid_state")
+            
+        if data.expires_at < datetime.now(datetime.timezone.utc):
+            raise HTTPException(status_code=400, detail="expired_code")
+        
+        access_token = uuid4().hex
+        new_refresh_token = uuid4().hex
+
+        tokens[access_token] = TokenInfo(
+            scopes={Scope(s) for s in data.scopes},
+            user=data.user,
+            expires_at=datetime.now(datetime.timezone.utc) + timedelta(hours=1),
+            iss=settings.app_url,
+            aud=client_id
+        )
+
+        refresh_tokens[new_refresh_token] = RefreshTokenInfo(
+            user=data.user,
+            scopes={Scope(s) for s in data.scopes},
+            expires_at=datetime.now(datetime.timezone.utc) + timedelta(days=7),
+            client_id=client_id
+        )
+
+        return TokenResponse(
+            access_token=access_token,
+            token_type="bearer",
+            expires_in=3600,
+            refresh_token=new_refresh_token,
+            scope=" ".join(data.scopes),
+        )
+
+    elif grant_type == "refresh_token":
+        if not refresh_token:
+            raise HTTPException(status_code=400, detail="missing_refresh_token")
+
+        if refresh_token not in refresh_tokens:
+            raise HTTPException(status_code=400, detail="invalid_refresh_token")
+        
+        refresh_token_data = refresh_tokens[refresh_token]
+
+        if refresh_token_data.expires_at < datetime.now(datetime.timezone.utc):
+            raise HTTPException(status_code=400, detail="expired_refresh_token")
+        
+        # Invalidate old refresh token
+        del refresh_tokens[refresh_token]
+
+        access_token = uuid4().hex
+        new_refresh_token = uuid4().hex
+
+        tokens[access_token] = TokenInfo(
+            scopes=refresh_token_data.scopes,
+            user=refresh_token_data.user,
+            expires_at=datetime.now(datetime.timezone.utc) + timedelta(hours=1),
+            iss=settings.app_url,
+            aud=refresh_token_data.client_id
+        )
+
+        refresh_tokens[new_refresh_token] = RefreshTokenInfo(
+            user=refresh_token_data.user,
+            scopes=refresh_token_data.scopes,
+            expires_at=datetime.now(datetime.timezone.utc) + timedelta(days=7),
+            client_id=refresh_token_data.client_id
+        )
+
+        return TokenResponse(
+            access_token=access_token,
+            token_type="bearer",
+            expires_in=3600,
+            refresh_token=new_refresh_token,
+            scope=" ".join(refresh_token_data.scopes),
+        )
+
+    else:
+        raise HTTPException(status_code=400, detail="unsupported_grant_type")
 
 
-class TokenResponse(BaseModel):
-    access_token: str
-    token_type: str
-    expires_in: int
-    refresh_token: str
-    scope: str
-
-
-class UserInfo(BaseModel):
-    sub: str
-    name: Optional[str] = None
-    picture: Optional[str] = None
-    email: Optional[str] = None
-
-
-@app.post("/token", response_model=TokenResponse)
-async def token(form_data: AuthorizationCodeRequestForm = Depends()):
-    if form_data.grant_type != "authorization_code" or form_data.code not in auth_codes:
-        raise HTTPException(status_code=400, detail="invalid_grant")
-    data = auth_codes.pop(form_data.code)
-    access_token = uuid4().hex
-    refresh_token = uuid4().hex
-    tokens[access_token] = {
-        "scopes": data["scopes"],
-        "user": data["user"],
-        "expires": datetime.utcnow() + timedelta(hours=1),
-    }
-    return TokenResponse(
-        access_token=access_token,
-        token_type="bearer",
-        expires_in=3600,
-        refresh_token=refresh_token,
-        scope=" ".join(data["scopes"]),
-    )
-
-
-@app.get("/userinfo", response_model=UserInfo)
-def userinfo(authorization: str = Header(...)):
-    try:
-        scheme, token = authorization.split()
-    except ValueError:
-        raise HTTPException(status_code=401, detail="invalid_request")
-    if scheme.lower() != "bearer" or token not in tokens:
-        raise HTTPException(status_code=401, detail="invalid_token")
-    data = tokens[token]
-    user = {"sub": data["user"]["sub"]}
-    scopes: Set[str] = data["scopes"]
-    if "profile" in scopes:
-        user.update({
-            "name": data["user"]["name"],
-            "picture": data["user"]["picture"],
-        })
-    if "email" in scopes:
-        user["email"] = data["user"]["email"]
-    return UserInfo(**user)
-
-
-@app.get("/")
-def root():
-    return {"message": "Mock OAuth2 Provider"}
+@app.get("/userinfo")
+def userinfo(token: Annotated[TokenInfo, Depends(get_session_data)]) -> UserInfo:
+    return token.user.from_scopes(token.scopes)
 
 
 if __name__ == "__main__":
     import uvicorn
+
 
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/oauth_mock.py
+++ b/oauth_mock.py
@@ -1,0 +1,130 @@
+from datetime import datetime, timedelta
+from typing import Dict, Set, Optional
+from uuid import uuid4
+
+from fastapi import Depends, FastAPI, Form, Header, HTTPException, Query
+from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
+from faker import Faker
+
+app = FastAPI()
+fake = Faker()
+
+auth_codes: Dict[str, Dict] = {}
+tokens: Dict[str, Dict] = {}
+
+VALID_SCOPES = {"openid", "profile", "email"}
+
+
+@app.get("/authorize")
+def authorize(
+    response_type: str = Query(...),
+    client_id: str = Query(...),
+    redirect_uri: str = Query(...),
+    scope: str = Query(""),
+    state: str = Query(""),
+):
+    if response_type != "code":
+        raise HTTPException(status_code=400, detail="unsupported_response_type")
+    scopes = set(scope.split()) if scope else set()
+    invalid_scopes = scopes - VALID_SCOPES
+    if invalid_scopes:
+        raise HTTPException(
+            status_code=400, detail=f"invalid_scope: {' '.join(invalid_scopes)}"
+        )
+    user = {
+        "sub": fake.uuid4(),
+        "name": fake.name(),
+        "email": fake.email(),
+        "picture": fake.image_url(),
+    }
+    code = uuid4().hex
+    auth_codes[code] = {"scopes": scopes, "user": user}
+    redirect = f"{redirect_uri}?code={code}"
+    if state:
+        redirect += f"&state={state}"
+    return RedirectResponse(redirect)
+
+
+class AuthorizationCodeRequestForm:
+    def __init__(
+        self,
+        grant_type: str = Form(...),
+        code: str = Form(...),
+        redirect_uri: str = Form(...),
+        client_id: str = Form(...),
+        client_secret: str = Form(...),
+    ):
+        self.grant_type = grant_type
+        self.code = code
+        self.redirect_uri = redirect_uri
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str
+    expires_in: int
+    refresh_token: str
+    scope: str
+
+
+class UserInfo(BaseModel):
+    sub: str
+    name: Optional[str] = None
+    picture: Optional[str] = None
+    email: Optional[str] = None
+
+
+@app.post("/token", response_model=TokenResponse)
+async def token(form_data: AuthorizationCodeRequestForm = Depends()):
+    if form_data.grant_type != "authorization_code" or form_data.code not in auth_codes:
+        raise HTTPException(status_code=400, detail="invalid_grant")
+    data = auth_codes.pop(form_data.code)
+    access_token = uuid4().hex
+    refresh_token = uuid4().hex
+    tokens[access_token] = {
+        "scopes": data["scopes"],
+        "user": data["user"],
+        "expires": datetime.utcnow() + timedelta(hours=1),
+    }
+    return TokenResponse(
+        access_token=access_token,
+        token_type="bearer",
+        expires_in=3600,
+        refresh_token=refresh_token,
+        scope=" ".join(data["scopes"]),
+    )
+
+
+@app.get("/userinfo", response_model=UserInfo)
+def userinfo(authorization: str = Header(...)):
+    try:
+        scheme, token = authorization.split()
+    except ValueError:
+        raise HTTPException(status_code=401, detail="invalid_request")
+    if scheme.lower() != "bearer" or token not in tokens:
+        raise HTTPException(status_code=401, detail="invalid_token")
+    data = tokens[token]
+    user = {"sub": data["user"]["sub"]}
+    scopes: Set[str] = data["scopes"]
+    if "profile" in scopes:
+        user.update({
+            "name": data["user"]["name"],
+            "picture": data["user"]["picture"],
+        })
+    if "email" in scopes:
+        user["email"] = data["user"]["email"]
+    return UserInfo(**user)
+
+
+@app.get("/")
+def root():
+    return {"message": "Mock OAuth2 Provider"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/pytest/oauth_test.py
+++ b/pytest/oauth_test.py
@@ -1,0 +1,154 @@
+import requests
+from fastapi import FastAPI, Request, HTTPException
+from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    provider: str = "http://oauth:8000"
+    provider_redirect: str = "http://localhost:8000"
+    redirect_uri: str = "http://localhost:8001/callback"
+    client_id: str
+    client_secret: str
+
+settings = Settings()
+app = FastAPI()
+
+# A simple in-memory store for our tokens
+# In a real app, this would be a persistent store
+tokens = {}
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str
+    expires_in: int
+    refresh_token: str
+    scope: str
+
+class UserInfoResponse(BaseModel):
+    sub: str
+    name: str | None = None
+    picture: str | None = None
+    email: str | None = None
+
+class AuthorizationRequest(BaseModel):
+    response_type: str
+    client_id: str
+    redirect_uri: str
+    scope: str
+    state: str
+
+class TokenExchangeRequest(BaseModel):
+    grant_type: str
+    code: str
+    redirect_uri: str
+    client_id: str
+    client_secret: str
+    state: str
+
+class RefreshTokenRequest(BaseModel):
+    grant_type: str
+    refresh_token: str
+
+@app.get("/")
+def home():
+    """
+    Simulates the client's homepage. Redirects to the authorization server to start the flow.
+    """
+
+    auth_params = AuthorizationRequest(
+        response_type="code",
+        client_id=settings.client_id,
+        redirect_uri=settings.redirect_uri,
+        scope="openid profile email",
+        state="a-unique-state-for-csrf-prevention"
+    )
+    auth_url = requests.Request(
+        'GET',
+        f"{settings.provider_redirect}/authorize",
+        params=auth_params.model_dump()
+    ).prepare().url
+    print(f"redirect to {auth_url}")
+    return RedirectResponse(auth_url)
+
+@app.get("/callback")
+async def callback(request: Request):
+    """
+    Receives the authorization code and exchanges it for a token.
+    This is the core of the client's authentication logic.
+    """
+    query_params = request.query_params
+    auth_code = query_params.get("code")
+    received_state = query_params.get("state")
+
+    if not auth_code:
+        raise HTTPException(status_code=400, detail="Authorization code missing.")
+
+    token_data = TokenExchangeRequest(
+        grant_type="authorization_code",
+        code=auth_code,
+        redirect_uri=settings.redirect_uri,
+        client_id=settings.client_id,
+        client_secret=settings.client_secret,
+        state=received_state
+    )
+
+    try:
+        response = requests.post(f"{settings.provider}/token", data=token_data.model_dump())
+        response.raise_for_status()
+        token_info = TokenResponse.model_validate(response.json())
+        
+        # Store the tokens for later use
+        tokens["access_token"] = token_info.access_token
+        tokens["refresh_token"] = token_info.refresh_token
+        
+        # Access a protected resource to show the access token works
+        userinfo_response = requests.get(
+            f"{settings.provider}/userinfo",
+            headers={"Authorization": f"Bearer {tokens['access_token']}"}
+        )
+        userinfo_response.raise_for_status()
+        user_data = UserInfoResponse.model_validate(userinfo_response.json())
+        
+        return {
+            "message": "Authentication successful!",
+            "user_info": user_data,
+            "tokens": token_info
+        }
+
+    except requests.exceptions.RequestException as e:
+        raise HTTPException(status_code=500, detail=f"Token exchange failed: {e}")
+
+@app.post("/refresh")
+def refresh_token_endpoint():
+    """
+    An endpoint to manually test the refresh token flow.
+    """
+    if not tokens.get("refresh_token"):
+        raise HTTPException(status_code=400, detail="No refresh token available.")
+
+    refresh_data = RefreshTokenRequest(
+        grant_type="refresh_token",
+        refresh_token=tokens["refresh_token"]
+    )
+
+    try:
+        response = requests.post(f"{settings.provider}/token", data=refresh_data.model_dump())
+        response.raise_for_status()
+        new_token_info = TokenResponse.model_validate(response.json())
+        tokens["access_token"] = new_token_info.access_token
+        tokens["refresh_token"] = new_token_info.refresh_token
+        
+        return {
+            "message": "Token refreshed successfully!",
+            "new_access_token": new_token_info.access_token
+        }
+    except requests.exceptions.RequestException as e:
+        raise HTTPException(status_code=500, detail=f"Token refresh failed: {e}")
+
+if __name__ == "__main__":
+    import uvicorn
+
+
+    uvicorn.run(app, host="0.0.0.0", port=8001)


### PR DESCRIPTION
## Summary
- refine FastAPI OAuth2 mock server with realistic authorization, token, and userinfo endpoints
- install Faker in Docker Compose service to generate user profile data
- refactor endpoints to use FastAPI Query parameters, a custom form class with Depends, and pydantic response models

## Testing
- `python -m py_compile oauth_mock.py`
- `docker-compose config` *(fails: command not found; attempted `pip install docker-compose` but installation failed)*

------
https://chatgpt.com/codex/tasks/task_e_689fc82562d4832b90558725ec572bbe